### PR TITLE
chore/tweak-paths

### DIFF
--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -29,15 +29,12 @@ done
 # if the org and repo variables are set
 if [[ -n "$ORG" && -n "$REPO" ]]; then
   sudo apt install -y git
-  if [ "$(basename "$PWD")" = ".setup" ]; then
-    cd ..
-  fi
-  if [ "$(basename "$PWD")" = "$REPO" ]; then
-    cd ..
-  fi
-  if [ "$(basename "$PWD")" = "$ORG" ]; then
-    cd ..
-  fi
+  folders=(".setup" "base" "cros-base" "cros-setup""$REPO" "$ORG")
+  for folder in "${folders[@]}"; do
+    if [ "$(basename "$PWD")" = "$folder" ]; then
+      cd ..
+    fi
+  done
   mkdir -p "$ORG"
   cd "$ORG"
   if [ ! -d "$REPO" ]; then


### PR DESCRIPTION
This pull request refactors the directory navigation logic in the `.setup/setup.sh` script to make it more maintainable and scalable. Instead of handling each directory separately with multiple conditional statements, the code now uses an array and a loop to check and navigate out of specific directories.

Directory navigation logic refactor:

* Replaced multiple individual `if` statements checking the current directory name (`.setup`, `$REPO`, `$ORG`) with a single array `folders` containing all relevant folder names, and a loop that iterates through them to handle directory changes more efficiently.