### PR TITLE
fix/terminal-input

### DIFF
--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -49,7 +49,7 @@ fi
 # Ensure main branch is checked out
 echo
 echo -ne "${YELLOW}Specify the branch to checkout [main]: ${NC}"
-read BRANCH_NAME
+read BRANCH_NAME < /dev/tty
 echo
 BRANCH_NAME=${BRANCH_NAME:-main}
 git checkout "$BRANCH_NAME"

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ This repository only includes those tools required to enable development using d
 1. Make sure you are in the directory where you want the repository to be cloned.
 2. Open the Chrome OS Linux terminal, then copy and paste the following text to download and run the setup scripts.
 ```bash
-bash <(curl -sS https://raw.githubusercontent.com/neilgfoster/base/main/.setup/setup.sh) -o=neilgfoster -r=cros-development
+bash <(curl -sS https://raw.githubusercontent.com/neilgfoster/base/cros-development/.setup/setup.sh) -o=neilgfoster -r=cros-development
 ```


### PR DESCRIPTION
This pull request makes minor improvements to the setup experience and documentation for the repository.

* Documentation update:
  * In `README.md`, the setup script URL now points to the `cros-development` branch instead of `main`, ensuring the correct setup script is used for Chrome OS development.

* Setup script usability:
  * In `.setup/setup.sh`, the `read` command for the branch name now explicitly reads from `/dev/tty`, improving compatibility and reliability when running the script in different environments.