### PR TITLE
feature/devcontainer-support

### DIFF
--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -25,34 +25,45 @@ for arg in "$@"; do
   esac
 done
 
-# Move to the correct directory and clone
-# if the org and repo variables are set
-if [[ -n "$ORG" && -n "$REPO" ]]; then
-  sudo apt install -y git
-  folders=(".setup" "base" "cros-base" "cros-setup" "$REPO" "$ORG")
-  for folder in "${folders[@]}"; do
-    if [ "$(basename "$PWD")" = "$folder" ]; then
-      cd ..
-    fi
-  done
-  mkdir -p "$ORG"
-  cd "$ORG"
-  if [ ! -d "$REPO" ]; then
-    git clone "https://github.com/$ORG/$REPO.git"
-  fi
-  cd "$REPO"
-  git pull
-  ./.setup/setup.sh
+
+# Devcontainer check
+# if repo contains .devcontainer folder but not running in a devcontainer, exit
+if [ -d ".devcontainer" ] && [ "${DEVCONTAINER}" != "true" ]; then
+  echo -e "${RED}Detected .devcontainer folder but not running in a devcontainer environment. Exiting${NC}"
   exit 0
 fi
 
-# Ensure main branch is checked out
-echo
-echo -ne "${YELLOW}Specify the branch to checkout [main]: ${NC}"
-read BRANCH_NAME < /dev/tty
-echo
-BRANCH_NAME=${BRANCH_NAME:-main}
-git checkout "$BRANCH_NAME"
+# Do not execute this section if running in a devcontainer
+if [ "${DEVCONTAINER}" != "true" ]; then
+
+  # Navigate to the correct directory and clone
+  if [[ -n "$ORG" && -n "$REPO" ]]; then
+    sudo apt install -y git
+    folders=(".setup" "base" "$REPO" "$ORG")
+    for folder in "${folders[@]}"; do
+      if [ "$(basename "$PWD")" = "$folder" ]; then
+        cd ..
+      fi
+    done
+    mkdir -p "$ORG"
+    cd "$ORG"
+    if [ ! -d "$REPO" ]; then
+      git clone "https://github.com/$ORG/$REPO.git"
+    fi
+    cd "$REPO"
+    git pull
+    ./.setup/setup.sh
+    exit 0
+  fi
+
+  # Prompt user for branch to checkout
+  echo
+  echo -ne "${YELLOW}Specify the branch to checkout [main]: ${NC}"
+  read BRANCH_NAME < /dev/tty
+  echo
+  BRANCH_NAME=${BRANCH_NAME:-main}
+  git checkout "$BRANCH_NAME"
+fi
 
 # Determine the directory of this setup.sh script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -39,7 +39,7 @@ if [ "${DEVCONTAINER}" != "true" ]; then
   # Navigate to the correct directory and clone
   if [[ -n "$ORG" && -n "$REPO" ]]; then
     sudo apt install -y git
-    folders=(".setup" "base" "$REPO" "$ORG")
+    folders=(".setup" "base" "cros-base" "cros-setup" "$REPO" "$ORG")
     for folder in "${folders[@]}"; do
       if [ "$(basename "$PWD")" = "$folder" ]; then
         cd ..


### PR DESCRIPTION
This pull request updates the `.setup/setup.sh` script to improve its behavior in development container environments and streamline the cloning and branch selection process. The most important changes are grouped below:

Devcontainer environment handling:

* Added a check to detect if the repository contains a `.devcontainer` folder and exits the script early if not running inside a devcontainer environment. This prevents accidental setup outside the intended environment.

Cloning and directory navigation improvements:

* Refactored the folder navigation logic by removing unnecessary folders from the list and ensuring it only runs when not in a devcontainer.

Branch selection enhancements:

* Replaced automatic checkout of the `main` branch with a user prompt to specify which branch to checkout, defaulting to `main` if no input is given.